### PR TITLE
Fix late _timer was not initialized but called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1]
+
+* Fix late _timer was not initialized but called
+
 ## [1.0.0]
 
 * Migraate to Nullsafety

--- a/lib/src/scroll_gallery.dart
+++ b/lib/src/scroll_gallery.dart
@@ -37,7 +37,7 @@ class _ScrollGalleryState extends State<ScrollGallery>
     with SingleTickerProviderStateMixin {
   late final ScrollController _scrollController;
   late final PageController _pageController;
-  late final Timer? _timer;
+  Timer? _timer;
   int _currentIndex = 0;
   bool _reverse = false;
   bool _lock = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ authors:
 - Anh Nguyen <razordmonkey@live.com>
 homepage: http://github.com/foodtiny/flutter_scroll_gallery
 description: A Flutter package that help you to create Image carousels with scroll thumbnail in bottom
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
If _timer was not initialized in initState an error was thrown in dispose method cause late _timer was not initialized
Fixes #12 